### PR TITLE
Update for Django 2.x/3.x and iframe support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -1,25 +1,55 @@
 [![PyPI](https://img.shields.io/pypi/v/django-sandstorm.svg)](https://pypi.python.org/pypi/django-sandstorm)
 
 # django-sandstorm
-Django package for helping integrate a django app with sandstorm.io
+Django package for helping integrate a Django app with sandstorm.io
 
-To use:
-`pip install django-sandstorm`
+To use: `pip install django-sandstorm`
 
 It is HIGHLY recommended you make a separate sandstorm settings file for your
 app. Whether or not you do, the following needs to go in your app settings for
 integration with sandstorm to work:
 
-```
-INSTALLED_APPS += (
-    'django_sandstorm',
-)
+1. Add `django_sandstorm` to `INSTALLED_APPS`
 
-AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.RemoteUserBackend',
-)
+        INSTALLED_APPS = [
+            ...
+            'django_sandstorm',
+        ]
+        
+1. Set `AUTHENTICATION_BACKENDS` to
+`django.contrib.auth.backends.RemoteUserBackend`. This is Django's built in
+backend for handling remote user authentication.
 
-MIDDLEWARE_CLASSES += (
-    'django_sandstorm.middleware.SandstormUserMiddleware',
-)
-```
+        AUTHENTICATION_BACKENDS = [
+            'django.contrib.auth.backends.RemoteUserBackend',
+        ]
+        
+1. Add `django_sandstorm.middleware.SandstormUserMiddleware` to 
+`MIDDLEWARE_CLASSES`. This middleware extends
+`django.contrib.auth.middleware.RemoteUserMiddleware` to add Sandstorm specific
+handling for remote user information.
+
+        MIDDLEWARE_CLASSES = [
+            ...
+            'django_sandstorm.middleware.SandstormUserMiddleware',
+        ]
+        
+    By default, this middleware creates a user with the Sandstorm User ID as a
+    username, sets the user `first_name` and `last_name` fields, and looks for
+    a default "admin" permission from Sandstorm, granting staff and superuser
+    status if it is found.
+    
+    Extend the `SandstormUserMiddleware` class to customize this behavior.
+
+1. Add `django_sandstorm.middleware.SandstormPreCsrfViewMiddleware` before
+`django.middleware.csrf.CsrfViewMiddleware` in `MIDDLEWARE_CLASSES`.
+
+        MIDDLEWARE_CLASSES = [
+            ...
+            'django_sandstorm.middleware.SandstormPreCsrfViewMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            ...
+        ]
+
+    Django requires a `Referer` header to be set for CSRF protection to work.
+    Sandstorm does not set this header, so the middleware is needed to add it.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ AUTHENTICATION_BACKENDS = (
 )
 
 MIDDLEWARE_CLASSES += (
-    'django_sandstorm.middleware.SandstormMiddleware',
+    'django_sandstorm.middleware.SandstormUserMiddleware',
 )
 ```

--- a/django_sandstorm/admin.py
+++ b/django_sandstorm/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
+from django.contrib.auth.models import Group, User
+
+
+class SandstormUserAdmin(UserAdmin):
+    def has_module_permission(self, request):
+        return False
+
+
+class SandstormGroupAdmin(GroupAdmin):
+    def has_module_permission(self, request):
+        return False
+
+
+admin.site.unregister(Group)
+admin.site.register(Group, SandstormGroupAdmin)
+admin.site.unregister(User)
+admin.site.register(User, SandstormUserAdmin)

--- a/django_sandstorm/context.py
+++ b/django_sandstorm/context.py
@@ -1,6 +1,0 @@
-from django.conf import settings
-
-def sandstorm(request):
-    if settings.SANDSTORM:
-        return {'SANDSTORM': True}
-    return {}

--- a/django_sandstorm/middleware.py
+++ b/django_sandstorm/middleware.py
@@ -1,23 +1,49 @@
-from django.contrib import auth
+from urllib.parse import unquote
+
 from django.contrib.auth.middleware import RemoteUserMiddleware
-from django.contrib.auth.models import User
 
-from six.moves.urllib.parse import unquote
 
-class SandstormMiddleware(RemoteUserMiddleware):
+class SandstormUserMiddleware(RemoteUserMiddleware):
     """
-    Requires 'django.contrib.auth.backends.RemoteUserBackend' in 
-    settings.AUTHENTICATION_BACKENDS
-    """
+    Middleware for handling Sandstorm user properties.
 
-    header = 'HTTP_X_SANDSTORM_USER_ID'
+    See: https://docs.sandstorm.io/en/latest/developing/auth/
+    """
+    header = "HTTP_X_SANDSTORM_USER_ID"
+    user_full_name = 'HTTP_X_SANDSTORM_USERNAME'
+    user_perms = 'HTTP_X_SANDSTORM_PERMISSIONS'
 
     def process_request(self, request):
-        super(SandstormMiddleware, self).process_request(request)
-
-        if request.META.get('HTTP_X_SANDSTORM_USERNAME') and hasattr(request, 'user'):
-            request.user.first_name = unquote(
-                request.META.get('HTTP_X_SANDSTORM_USERNAME')
-            )
-            if request.user.is_authenticated():
+        super().process_request(request)
+        if hasattr(request, 'user') and request.user.is_authenticated:
+            user_original = request.user
+            self.update_user_metadata(request)
+            self.update_user_permissions(request)
+            if request.user != user_original:
                 request.user.save()
+
+    def update_user_metadata(self, request):
+        """
+        Update metadata about the user based on Sandstorm headers.
+        """
+        # Set first and last name.
+        if self.user_full_name in request.META:
+            name = unquote(request.META.get(self.user_full_name))
+            name_parts = name.split(' ')
+            if hasattr(request.user, 'first_name'):
+                request.user.first_name = name_parts[0]
+            if hasattr(request.user, 'last_name') and len(name_parts) > 1:
+                request.user.last_name = ' '.join(name_parts[1:])
+
+    def update_user_permissions(self, request):
+        """
+        Update user permissions based on Sandstorm headers.
+
+        This method assumes a default "admin" permission that is granted staff
+        and superuser status in Django.
+        """
+        if self.user_perms in request.META:
+            perms = request.META.get(self.user_perms).split(',')
+            if 'admin' in perms:
+                request.user.is_staff = True
+                request.user.is_superuser = True

--- a/django_sandstorm/middleware.py
+++ b/django_sandstorm/middleware.py
@@ -1,6 +1,7 @@
 from urllib.parse import unquote
 
 from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.utils.deprecation import MiddlewareMixin
 
 
 class SandstormUserMiddleware(RemoteUserMiddleware):
@@ -47,3 +48,12 @@ class SandstormUserMiddleware(RemoteUserMiddleware):
             if 'admin' in perms:
                 request.user.is_staff = True
                 request.user.is_superuser = True
+
+
+class SandstormPreCsrfViewMiddleware(MiddlewareMixin):
+    base_path = 'HTTP_X_SANDSTORM_BASE_PATH'
+    referrer = 'HTTP_REFERER'
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        if self.base_path in request.META:
+            request.META[self.referrer] = request.META[self.base_path]

--- a/django_sandstorm/middleware.py
+++ b/django_sandstorm/middleware.py
@@ -40,13 +40,14 @@ class SandstormUserMiddleware(RemoteUserMiddleware):
         """
         Update user permissions based on Sandstorm headers.
 
-        This method assumes a default "admin" permission that is granted staff
-        and superuser status in Django.
+        This method assumes Sandstorm permissions matching the "staff" and
+        "superuser" conventions in Django.
         """
         if self.user_perms in request.META:
             perms = request.META.get(self.user_perms).split(',')
-            if 'admin' in perms:
+            if 'staff' in perms:
                 request.user.is_staff = True
+            if 'superuser' in perms:
                 request.user.is_superuser = True
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,6 @@ setup(
     packages=['django_sandstorm'],
     include_package_data=True,
     license='MIT License',
-    install_requires=[
-        'six',
-    ],
     description='A sandstorm.io integration for Django.',
     long_description=README,
     url='https://github.com/phildini/django-sandstorm',


### PR DESCRIPTION
Per discussion with @ocdtrekkie over email, this is a collection of updates to get django-sandstorm to better support Django 2.x/3.x.

Currently, Django 2.x/3.x applications do not work in Sandstorm because Sandstorm does not maintain a `Referer` header with requests and Django requires it for CSRF protection. This PR addresses that by populating the `Referer` header with the value of the `X-Sandstorm-Base-Path` header. This compromises the level of security of the CSRF protection, but without it Django 2.x/3.x will not work in Sandstorm.

This PR also adds support for "staff" and "superuser" permissions from Sandstorm to match the convention used in Django and expands support for Sandstorm user names (to parse a first and last name).

If this project is no longer maintained, I am interested in taking over maintainership if that is an option.